### PR TITLE
Add PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,31 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      # Publish on any tag starting with a `v`, e.g., v0.1.0
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Build
+        run: uv build
+
+      - name: Publish
+        run: uv publish


### PR DESCRIPTION
## Summary
- Added `.github/workflows/publish.yaml` for automated PyPI publishing
- Workflow triggers on version tags (e.g., `v0.1.0`, `v1.2.3`)
- Uses `release` environment for deployment protection
- Leverages PyPI trusted publishing (OpenID Connect) - no manual credential management
- Builds package with `uv build` and publishes with `uv publish`

## Setup Required
1. Create `release` environment in GitHub Settings → Environments
2. Configure PyPI trusted publishing in PyPI project settings
   - Match GitHub organization, repository, workflow filename, and environment name

## Usage
To publish a new release:
```bash
git tag -a v0.1.0 -m "Release v0.1.0"
git push origin v0.1.0
```

## Test plan
- [x] Verify workflow syntax is correct
- [x] Confirm environment configuration is set to `release`
- [x] Review trusted publishing permissions are properly configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)