### PR TITLE
Add PyPI URL to project metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
 [project.urls]
 Repository = "https://github.com/datacircus/pyspark-streaming-base"
 Releases = "https://github.com/datacircus/pyspark-streaming-base/releases"
+PyPI = "https://pypi.org/project/pyspark-streaming-base/"
 
 [build-system]
 requires = ["uv_build>=0.9.8,<0.10.0"]


### PR DESCRIPTION
## Summary
- Added PyPI project URL to `pyproject.toml` in the `[project.urls]` section
- Makes it easier for users to discover the published package on PyPI

## Changes
- Updated `pyproject.toml` to include: `PyPI = "https://pypi.org/project/pyspark-streaming-base/"`

## Test plan
- [ ] Verify pyproject.toml syntax is valid
- [ ] Confirm the URL is correct and accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)