### PR TITLE
Add RuntimeConf examples and comprehensive documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,8 @@ __marimo__/
 # specific to this project
 tests/resources/checkpoints/test:streaming:delta_source_to_delta_sink
 tests/resources/delta_streaming_sink/covid19
+tests/resources/checkpoints/test:streaming:delta_end_to_end/
+tests/resources/delta_streaming_sink/covid19_e2e/
 
 .DS_Store
 */DS_Store

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,358 @@
+# Getting Started with pyspark-streaming-base
+
+This guide provides an overview of how to build bullet-proof Spark Structured Streaming applications using the `pyspark-streaming-base` framework.
+
+## Table of Contents
+
+- [Core Concepts](#core-concepts)
+- [Configuration Approaches](#configuration-approaches)
+- [RuntimeConf Approach (Recommended for Testing)](#runtimeconf-approach-recommended-for-testing)
+- [Builder Pattern Approach](#builder-pattern-approach)
+- [Complete Example: Delta-to-Delta Streaming](#complete-example-delta-to-delta-streaming)
+- [Key Configuration Keys](#key-configuration-keys)
+- [Testing Your Application](#testing-your-application)
+
+## Core Concepts
+
+The `pyspark-streaming-base` framework provides three main components:
+
+1. **StreamingApp**: The foundation that manages your SparkSession, checkpoint locations, and application lifecycle
+2. **StreamingSource**: Abstractions for reading from Kafka and Delta Lake
+3. **StreamingSink**: Abstractions for writing to Delta Lake
+
+All configuration follows a **three-tier approach**:
+1. Default values (hardcoded in the library)
+2. SparkSession config (retrieved via `spark.conf`)
+3. Direct config (passed via constructors or `with_config()`)
+
+## Configuration Approaches
+
+There are two primary ways to configure your streaming application:
+
+### 1. RuntimeConf Approach (Recommended for Testing)
+
+Directly set configuration on the SparkSession's `RuntimeConf` before initializing the application. This approach provides maximum flexibility and is ideal for testing scenarios.
+
+### 2. Builder Pattern Approach (Recommended for Production)
+
+Use the fluent `.with_config()` method to configure components. This approach is more declarative and works well with configuration files.
+
+## RuntimeConf Approach (Recommended for Testing)
+
+The RuntimeConf approach gives you fine-grained control over the SparkSession configuration **before** the application is initialized.
+
+### Pattern
+
+```python
+from pyspark_streaming_base.app import StreamingApp
+
+# Step 1: Create the application (without initialization)
+app = StreamingApp()
+
+# Step 2: Define all configurations in a single dictionary
+spark_config = {
+    # Application settings
+    'spark.app.name': 'my-streaming-app',
+    'spark.app.version': '1.0.0',
+    'spark.app.checkpoints.path': '/path/to/checkpoints',
+    'spark.app.checkpoint.version': '1.0.0',
+
+    # Source configurations
+    'spark.app.source.delta.options.path': '/path/to/source/table',
+    'spark.app.source.delta.options.startingVersion': '0',
+
+    # Sink configurations
+    'spark.app.sink.delta.options.path': '/path/to/sink/table',
+    'spark.app.sink.delta.options.outputMode': 'append',
+}
+
+# Step 3: Apply configurations to SparkSession RuntimeConf
+for key, value in spark_config.items():
+    app.spark.conf.set(key, value)
+
+# Step 4: Initialize the application
+app.initialize()
+
+# Step 5: Configure sources and sinks (they read from RuntimeConf automatically)
+from pyspark_streaming_base.sources import DeltaStreamingSource
+from pyspark_streaming_base.sinks import DeltaStreamingSink
+
+delta_source = DeltaStreamingSource(config_prefix='spark.app.source')
+delta_sink = DeltaStreamingSink(config_prefix='spark.app.sink')
+
+app.with_source(delta_source)
+app.with_sink(delta_sink)
+
+# Step 6: Run your streaming query
+df = app.delta_source().generate().load()
+query = delta_sink.fromDF(df).start()
+query.awaitTermination()
+```
+
+### Why Use RuntimeConf?
+
+- **Centralized configuration**: All configs in one place for easy review
+- **Testing flexibility**: Easy to modify configs in test scenarios
+- **Environment-specific settings**: Load configs from environment variables or files
+- **Debugging**: Clear visibility into what configurations are being applied
+
+### Important Notes
+
+⚠️ **Configuration Key Precision**: Pay attention to singular vs. plural in config keys:
+- `spark.app.checkpoint.version` (singular) - NOT `checkpoints.version`
+- `spark.app.checkpoints.path` (plural)
+
+⚠️ **Initialization Order**: You must call `app.initialize()` **after** setting RuntimeConf values, or they won't be picked up.
+
+## Builder Pattern Approach
+
+The builder pattern uses method chaining with `.with_config()` for a more declarative style.
+
+### Pattern
+
+```python
+from pyspark_streaming_base.app import StreamingApp
+from pyspark_streaming_base.sources import DeltaStreamingSource
+from pyspark_streaming_base.sinks import DeltaStreamingSink
+
+app = (
+    StreamingApp()
+    .with_config({
+        'spark.app.name': 'my-streaming-app',
+        'spark.app.version': '1.0.0',
+        'spark.app.checkpoints.path': '/path/to/checkpoints',
+        'spark.app.checkpoint.version': '1.0.0',
+    })
+    .initialize()
+)
+
+delta_source = (
+    DeltaStreamingSource(config_prefix='spark.app.source')
+    .with_config({
+        'spark.app.source.delta.options.path': '/path/to/source/table',
+        'spark.app.source.delta.options.startingVersion': '0',
+    })
+)
+
+delta_sink = (
+    DeltaStreamingSink(config_prefix='spark.app.sink')
+    .with_config({
+        'spark.app.sink.delta.options.path': '/path/to/sink/table',
+        'spark.app.sink.delta.options.outputMode': 'append',
+    })
+)
+
+app.with_source(delta_source).with_sink(delta_sink)
+
+df = app.delta_source().generate().load()
+query = delta_sink.fromDF(df).start()
+query.awaitTermination()
+```
+
+### Alternative: Constructor Pattern
+
+You can also pass configuration directly to the constructor:
+
+```python
+app = StreamingApp(
+    app_config={
+        'spark.app.name': 'my-streaming-app',
+        'spark.app.checkpoints.path': '/path/to/checkpoints',
+        'spark.app.checkpoint.version': '1.0.0',
+    }
+)
+# No need to call initialize() - it's automatic when using constructor config
+```
+
+## Complete Example: Delta-to-Delta Streaming
+
+This example demonstrates a complete end-to-end streaming application that reads from one Delta table and writes to another.
+
+```python
+from pathlib import Path
+from pyspark.sql import DataFrame
+from pyspark.sql.streaming import StreamingQuery
+from pyspark_streaming_base.app import StreamingApp
+from pyspark_streaming_base.sources import DeltaStreamingSource
+from pyspark_streaming_base.sinks import DeltaStreamingSink
+
+# Define paths and names
+source_table_path = Path('/data/source/table')
+sink_table_path = Path('/data/sink/table')
+checkpoints_path = Path('/data/checkpoints')
+
+# Create configuration dictionary
+spark_config = {
+    # Application settings
+    'spark.app.name': 'delta-to-delta-streaming',
+    'spark.app.version': '1.0.0',
+    'spark.app.checkpoints.path': checkpoints_path.as_posix(),
+    'spark.app.checkpoint.version': '1.0.0',
+
+    # Source: Delta table configuration
+    'spark.app.source.delta.options.path': source_table_path.as_posix(),
+    'spark.app.source.delta.options.startingVersion': '0',
+    'spark.app.source.delta.options.maxFilesPerTrigger': '10',
+    'spark.app.source.delta.options.ignoreChanges': 'true',
+
+    # Sink: Delta table configuration
+    'spark.app.sink.delta.options.path': sink_table_path.as_posix(),
+    'spark.app.sink.delta.options.outputMode': 'append',
+    'spark.app.sink.delta.options.mergeSchema': 'true',
+    'spark.app.sink.delta.options.maxRecordsPerFile': '100000',
+}
+
+# Create and configure the application
+app = StreamingApp()
+
+# Apply all configurations to Spark RuntimeConf
+for key, value in spark_config.items():
+    app.spark.conf.set(key, value)
+
+# Initialize the application
+app.initialize()
+
+# Create source and sink (they automatically read from RuntimeConf)
+delta_source = DeltaStreamingSource(config_prefix='spark.app.source')
+delta_sink = DeltaStreamingSink(config_prefix='spark.app.sink')
+
+# Attach to the application
+app.with_source(delta_source)
+app.with_sink(delta_sink)
+
+# Generate the streaming DataFrame
+df: DataFrame = app.delta_source().generate().load()
+
+# Start the streaming query
+sink_options = app.delta_sink().options()
+query: StreamingQuery = (
+    delta_sink.fromDF(df)
+    .trigger(availableNow=True)  # Process all available data
+    .outputMode(sink_options['outputMode'])
+    .start()
+)
+
+# Wait for completion or run indefinitely
+query.awaitTermination()
+```
+
+## Key Configuration Keys
+
+### Application-Level
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `spark.app.name` | Application name (required) | `'my-streaming-app'` |
+| `spark.app.version` | Application version | `'1.0.0'` |
+| `spark.app.checkpoints.path` | Base path for checkpoints (required) | `'/data/checkpoints'` |
+| `spark.app.checkpoint.version` | Checkpoint version for isolation (required) | `'1.0.0'` |
+
+### Delta Source
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `spark.app.source.delta.options.path` | Path to Delta table | `'/data/source/table'` |
+| `spark.app.source.delta.options.startingVersion` | Delta version to start from | `'0'` or `'latest'` |
+| `spark.app.source.delta.options.maxFilesPerTrigger` | Throttle files per batch | `'10'` |
+| `spark.app.source.delta.options.ignoreChanges` | Ignore schema changes | `'true'` or `'false'` |
+| `spark.app.source.delta.options.withEventTimeOrder` | Order by event time | `'true'` or `'false'` |
+
+### Delta Sink
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `spark.app.sink.delta.options.path` | Output path | `'/data/sink/table'` |
+| `spark.app.sink.delta.options.outputMode` | Output mode | `'append'`, `'complete'`, `'update'` |
+| `spark.app.sink.delta.options.mergeSchema` | Allow schema evolution | `'true'` or `'false'` |
+| `spark.app.sink.delta.options.maxRecordsPerFile` | Records per file limit | `'100000'` |
+| `spark.app.sink.delta.options.checkpointLocation` | Custom checkpoint path | Auto-set from app |
+
+### Kafka Source
+
+| Key | Description | Example |
+|-----|-------------|---------|
+| `spark.app.source.topic` | Kafka topic to consume | `'my-topic'` |
+| `spark.app.source.kafka.options.kafka.bootstrap.servers` | Kafka brokers | `'localhost:9092'` |
+| `spark.app.source.kafka.options.startingOffsets` | Starting offset | `'earliest'` or `'latest'` |
+| `spark.app.source.kafka.options.maxOffsetsPerTrigger` | Throttle records | `'1000'` |
+
+## Testing Your Application
+
+### Basic Test Pattern
+
+```python
+import pytest
+from pathlib import Path
+from pyspark.sql import DataFrame
+from pyspark_streaming_base.app import StreamingApp
+
+def test_my_streaming_app():
+    # Setup
+    test_source_path = Path(__file__).parent / 'resources' / 'source_table'
+    test_sink_path = Path(__file__).parent / 'resources' / 'sink_table'
+
+    spark_config = {
+        'spark.app.name': 'test-streaming-app',
+        'spark.app.checkpoints.path': '/tmp/checkpoints',
+        'spark.app.checkpoint.version': '1.0.0',
+        'spark.app.source.delta.options.path': test_source_path.as_posix(),
+        'spark.app.sink.delta.options.path': test_sink_path.as_posix(),
+    }
+
+    app = StreamingApp()
+    for key, value in spark_config.items():
+        app.spark.conf.set(key, value)
+    app.initialize()
+
+    # ... configure sources and sinks ...
+
+    # Run streaming query
+    query.processAllAvailable()
+
+    # Verify results
+    result_df = app.spark.read.format('delta').load(test_sink_path.as_posix())
+    assert result_df.count() > 0
+```
+
+### Data Quality Testing
+
+Go beyond simple row counts by validating data quality:
+
+```python
+from pyspark.sql.functions import col, sum as spark_sum, when
+
+def test_data_quality():
+    # ... setup and run streaming query ...
+
+    result_df = app.spark.read.format('delta').load(sink_path)
+
+    # Verify data was written
+    row_count = result_df.count()
+    assert row_count > 0, "Expected data to be written"
+
+    # Compute non-null fingerprint across all columns
+    non_null_counts = result_df.select([
+        spark_sum(when(col(c).isNotNull(), 1).otherwise(0)).alias(f"{c}_non_null")
+        for c in result_df.columns
+    ]).collect()[0]
+
+    total_non_null_values = sum(non_null_counts.asDict().values())
+    assert total_non_null_values > row_count, "Expected meaningful data, not empty rows"
+```
+
+## Tips and Best Practices
+
+1. **Choose the Right Approach**: Use RuntimeConf for testing and flexibility, use builder pattern for production clarity
+2. **Configuration Prefixes**: Use different prefixes (e.g., `spark.app.source2`) for multiple sources/sinks
+3. **Checkpoint Isolation**: Always set `spark.app.checkpoint.version` to isolate different versions of your app
+4. **Schema Evolution**: Enable `mergeSchema` on sinks if your schema might change over time
+5. **Throttling**: Use `maxFilesPerTrigger` (Delta) or `maxOffsetsPerTrigger` (Kafka) to control throughput
+6. **Testing**: Use `trigger(availableNow=True)` in tests to process all data without waiting
+
+## Next Steps
+
+- Check out the test examples in `tests/test_delta_end_to_end.py`
+- Review the `CLAUDE.md` file for architecture details
+- Explore the source code in `src/pyspark_streaming_base/`
+
+For more information, visit the [GitHub repository](https://github.com/datacircus/pyspark-streaming-base).

--- a/tests/test_delta_end_to_end.py
+++ b/tests/test_delta_end_to_end.py
@@ -1,0 +1,111 @@
+from pyspark.sql import DataFrame
+from pyspark.sql.streaming import StreamingQuery
+from pyspark_streaming_base.app import StreamingApp
+from pyspark_streaming_base.sinks import DeltaStreamingSink
+from pyspark_streaming_base.sources.delta_source import DeltaStreamingSource
+from pathlib import Path
+
+def test_delta_end_to_end():
+
+    delta_source_table_name = 'test_table'
+    test_app_name = 'test:streaming:delta_end_to_end'
+    checkpoints_path = Path(__file__).parent.joinpath('./resources/checkpoints/').absolute().as_posix()
+    delta_sink_table_name = 'covid19_e2e'
+    delta_sink_table_dir = (Path(__file__).parent.joinpath('./resources/delta_streaming_sink/')
+                            .joinpath(delta_sink_table_name).absolute())
+
+    spark_config: dict[str, str] = {
+        'spark.app.name': test_app_name,
+        'spark.app.version': '0.0.1',
+        'spark.app.checkpoints.path': checkpoints_path,
+        'spark.app.checkpoint.version': '1.0.0',
+        # we can't time travel to versions that don't exist, so start at 0
+        # since this is the same behavior as a fresh table read
+        'spark.app.source.delta.options.startingVersion': '0',
+        'spark.app.source.delta.options.maxFilesPerTrigger': '4',
+        'spark.app.source.delta.options.ignoreChanges': 'true',
+        'spark.app.source.delta.options.withEventTimeOrder': 'true',
+        # if the table has a path, then we expect it is unmanaged
+        'spark.app.source.delta.options.path': Path(__file__).parent
+        .joinpath('resources/delta_streaming_source', delta_source_table_name).absolute().as_posix(),
+        'spark.app.source.delta.table.tableName': delta_source_table_name,
+        # 'spark.app.source.delta.table.databaseOrSchema': 'default',
+        # 'spark.app.source.delta.table.catalog': 'development'
+        'spark.app.sink.delta.options.checkpointLocation': Path(__file__).parent.joinpath('./resources/checkpoints/').joinpath(test_app_name).joinpath('1.0.0').joinpath('_checkpoints').absolute().as_posix(),
+        'spark.app.sink.delta.options.maxRecordsPerFile': '100000',
+        'spark.app.sink.delta.options.mergeSchema': 'true',
+        'spark.app.sink.delta.options.queryName': 'delta:sink:covid19',
+        'spark.app.sink.delta.options.outputMode': 'append',
+        'spark.app.sink.delta.options.path': delta_sink_table_dir.as_posix(),
+        'spark.app.sink.delta.table.name': delta_sink_table_name,
+        'spark.app.sink.delta.trigger.enabled': 'true',
+        'spark.app.sink.delta.trigger.availableNow': 'true',
+    }
+
+    app: StreamingApp = StreamingApp()
+
+    # Apply spark config to the app's SparkSession
+    for key, value in spark_config.items():
+        app.spark.conf.set(key, value)
+
+    app.initialize()
+
+    # separate generation of the delta source
+    delta_source: DeltaStreamingSource = (
+        DeltaStreamingSource(config_prefix='spark.app.source')
+    )
+
+    # apply the source to the app
+    app.with_source(delta_source)
+
+    # create the sink options
+    delta_sink: DeltaStreamingSink = (
+        DeltaStreamingSink(config_prefix='spark.app.sink')
+    )
+
+    app.with_sink(delta_sink)
+
+    sink_options = app.delta_sink().options()
+    assert sink_options['checkpointLocation'] == app.checkpoint_location().as_posix()
+    assert sink_options['maxRecordsPerFile'] == '100000'
+
+    df: DataFrame = app.delta_source().generate().load()
+    assert df.isStreaming is True
+
+    query: StreamingQuery = (
+        delta_sink.fromDF(df)
+        .queryName(sink_options['queryName'])
+        .trigger(availableNow=True)
+        .outputMode(sink_options['outputMode'])
+        .start()
+    )
+
+    # try writing all data from the 'test_table' source -> 'covid19' sink
+    query.processAllAvailable()
+
+    # Read the results from the delta sink table
+    result_df: DataFrame = (
+        app.spark.read.format('delta')
+        .load(delta_sink_table_dir.as_posix())
+    )
+
+    # Novel test: verify data was written by checking that the result set
+    # contains actual data and compute a simple data fingerprint
+    row_count = result_df.count()
+    assert row_count > 0, "Expected data to be written to sink table"
+
+    # Compute a deterministic fingerprint: count of non-null values across all columns
+    # This ensures we not only have rows, but they contain actual data
+    from pyspark.sql.functions import col, sum as spark_sum, when
+
+    non_null_counts = result_df.select([
+        spark_sum(when(col(c).isNotNull(), 1).otherwise(0)).alias(f"{c}_non_null")
+        for c in result_df.columns
+    ]).collect()[0]
+
+    total_non_null_values = sum(non_null_counts.asDict().values())
+    assert total_non_null_values > row_count, "Expected meaningful data, not just empty rows"
+
+    # Verify the table has the expected structure by checking column count
+    assert len(result_df.columns) > 0, "Expected table to have columns"
+

--- a/tests/test_streaming_app.py
+++ b/tests/test_streaming_app.py
@@ -2,7 +2,7 @@ import pytest
 
 from pyspark_streaming_base.app import StreamingApp
 
-expected_checkpoint_dir = '/src/test/resources/pyspark_streaming_base:default:app/stable/_checkpoints'
+expected_checkpoint_dir = '/src/test/resources/pyspark_streaming_base:default:app/1.0.0/_checkpoints'
 
 def test_app_init():
     app: StreamingApp = (
@@ -14,7 +14,7 @@ def test_app_init():
         .with_config({
             'spark.app.name': 'pyspark_streaming_base:default:app',
             'spark.app.checkpoints.path': '/src/test/resources/',
-            'spark.app.checkpoints.version': '1.0.0'
+            'spark.app.checkpoint.version': '1.0.0'
         })
         .initialize()
     )
@@ -30,7 +30,7 @@ def test_app_simple_init():
         app_config={
             'spark.app.name': 'pyspark_streaming_base:default:app',
             'spark.app.checkpoints.path': '/src/test/resources/',
-            'spark.app.checkpoints.version': '1.0.0'
+            'spark.app.checkpoint.version': '1.0.0'
         }
     )
     # note: there is no need to initialize here since


### PR DESCRIPTION
## Summary
- Added new end-to-end test demonstrating the RuntimeConf configuration approach
- Created comprehensive `overview.md` documentation for getting started with the framework
- Fixed configuration key inconsistencies across existing tests

## Key Changes

### New Test: `test_delta_end_to_end.py`
- Demonstrates RuntimeConf approach: configure SparkSession before initialization
- Shows Delta-to-Delta streaming workflow
- Includes novel data quality testing using fingerprint validation
- Uses `when().otherwise()` pattern for conditional logic

### Documentation: `docs/overview.md`
- Complete getting started guide for new users
- Compares RuntimeConf vs Builder Pattern approaches
- Full Delta-to-Delta streaming example with explanation
- Configuration reference tables for all major settings
- Testing patterns and best practices
- Tips based on real development experience

### Bug Fix: Configuration Key Correction
- Fixed `spark.app.checkpoints.version` → `spark.app.checkpoint.version` (singular)
- Updated tests to use correct checkpoint version configuration
- All 6 tests passing

## Testing
```bash
make test
# ============================== 6 passed in 7.35s ===============================
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)