### PR TITLE
Add version bump command and bump to 0.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ dev:
 version:
 	@uv version --short
 
+bump:
+	@uv version --bump patch
+
 build:
 	@uv sync
 	@uv run ruff check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyspark-streaming-base"
-version = "0.1.0"
+version = "0.1.1"
 description = "This project provides a set of base classes that simplify the art of crafting bullet-proof Spark Structured Streaming applications."
 keywords = ["pyspark", "structured streaming", "kafka", "delta lake"]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -153,7 +153,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/ae/40/1414582f16c1d7b05
 
 [[package]]
 name = "pyspark-streaming-base"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "delta-spark" },


### PR DESCRIPTION
## Summary
- Added `make bump` command to simplify version bumping workflow
- Bumped project version from 0.1.0 to 0.1.1
- Updated dependency lock file

## Changes

### New Makefile Command
```makefile
bump:
	@uv version --bump patch
```

This command automates the version bumping process using `uv version --bump patch`, which:
- Increments the patch version (0.1.0 → 0.1.1)
- Updates `pyproject.toml`
- Rebuilds and reinstalls the package
- Updates `uv.lock`

### Usage
```bash
make bump    # Bump patch version
make version # Verify current version
```

### Version Confirmation
```bash
$ make version
0.1.1
```

## Benefits
- Simplifies version management workflow
- Ensures consistent version bumping process
- Automatically handles lock file updates
- Prepares for release automation

🤖 Generated with [Claude Code](https://claude.com/claude-code)