### PR TITLE
Fix README links for PyPI and bump to 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ query.awaitTermination()
 ### Documentation
 
 For comprehensive documentation including configuration reference, testing patterns, and best practices, see:
-- [Complete Getting Started Guide](./docs/overview.md)
-- [Developer Guide (CLAUDE.md)](./CLAUDE.md)
+- [Complete Getting Started Guide](https://github.com/datacircus/pyspark-streaming-base/blob/main/docs/overview.md)
+- [Developer Guide (CLAUDE.md)](https://github.com/datacircus/pyspark-streaming-base/blob/main/CLAUDE.md)
 
 ## Local Developer Environment
 
@@ -109,7 +109,7 @@ For comprehensive documentation including configuration reference, testing patte
 
 - **Python 3.13+** - Managed via [uv](https://docs.astral.sh/uv/guides/install-python/)
 - **Java 17 or 21** - Required for PySpark 4.0.1 (Spark uses Scala 2.13)
-- **PySpark 4.0.1** - Specified in [pyproject.toml](./pyproject.toml)
+- **PySpark 4.0.1** - Specified in [pyproject.toml](https://github.com/datacircus/pyspark-streaming-base/blob/main/pyproject.toml)
 
 ### Java Setup (Mac)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pyspark-streaming-base"
-version = "0.1.1"
+version = "0.1.2"
 description = "This project provides a set of base classes that simplify the art of crafting bullet-proof Spark Structured Streaming applications."
 keywords = ["pyspark", "structured streaming", "kafka", "delta lake"]
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -153,7 +153,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/ae/40/1414582f16c1d7b05
 
 [[package]]
 name = "pyspark-streaming-base"
-version = "0.1.1"
+version = "0.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "delta-spark" },


### PR DESCRIPTION
## Summary
- Fixed broken relative links in README.md to use absolute GitHub URLs
- Bumped version from 0.1.1 to 0.1.2
- Ensures documentation links work correctly on PyPI package page

## Problem
After releasing 0.1.1, the README on PyPI had broken links because relative paths (like `./docs/overview.md`) don't work on PyPI.

## Solution
Updated all relative links to use absolute GitHub URLs with the pattern:
```
https://github.com/datacircus/pyspark-streaming-base/blob/main/
```

## Changes

### Fixed Links
- `./docs/overview.md` → `https://github.com/datacircus/pyspark-streaming-base/blob/main/docs/overview.md`
- `./CLAUDE.md` → `https://github.com/datacircus/pyspark-streaming-base/blob/main/CLAUDE.md`
- `./pyproject.toml` → `https://github.com/datacircus/pyspark-streaming-base/blob/main/pyproject.toml`

### Version Bump
- Bumped from 0.1.1 to 0.1.2
- Updated `pyproject.toml` and `uv.lock`

## Testing
✅ All links verified to work correctly on GitHub
✅ Links will work on PyPI package page after release

## Next Steps
After merge, tag and release v0.1.2 to publish updated README to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)